### PR TITLE
Bump the Arrow version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "8.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce240772a007c63658c1d335bb424fd1019b87895dee899b7bf70e85b2d24e5f"
+checksum = "5c6bee230122beb516ead31935a61f683715f987c6f003eff44ad6986624105a"
 dependencies = [
  "bitflags",
  "chrono",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "2.0.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4c5738bcd7fad10315029c50026f83c9da5e4a21f8ed66826f43e0e2bde5f6"
+checksum = "86b428b715fdbdd1c364b84573b5fdc0f84f8e423661b9f398735278bc7f2b6a"
 dependencies = [
  "bitflags",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6bee230122beb516ead31935a61f683715f987c6f003eff44ad6986624105a"
+checksum = "1cdc4456252b8108b914f41450a754d23b8d21299322f24f81fc46a834fa0293"
 dependencies = [
  "bitflags",
  "chrono",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-arrow = "13.0"
+arrow = "16.0"
 serde = { version = "1.0", features = ["derive"] }
 
 serde_arrow = { path = "../serde_arrow" }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-arrow = "8.0"
+arrow = "13.0"
 serde = { version = "1.0", features = ["derive"] }
 
 serde_arrow = { path = "../serde_arrow" }

--- a/serde_arrow/Cargo.toml
+++ b/serde_arrow/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = "13.0"
+arrow = "16.0"
 serde = "1.0"
 
 # TODO: make optional, only required for str -> date conversions

--- a/serde_arrow/Cargo.toml
+++ b/serde_arrow/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = "8.0"
+arrow = "13.0"
 serde = "1.0"
 
 # TODO: make optional, only required for str -> date conversions


### PR DESCRIPTION
This upgrades to the latest version of the `arrow` crate (`13.0`).