### PR TITLE
Add data type to error message when failing to convert an array

### DIFF
--- a/serde_arrow/src/arrow_impl/deserialization.rs
+++ b/serde_arrow/src/arrow_impl/deserialization.rs
@@ -36,7 +36,7 @@ impl BufferExtract for dyn Array {
                     .downcast_ref::<PrimitiveArray<$arrow_type>>()
                     .ok_or_else(|| {
                         error!(
-                            "Cannot interpret {} array as {}",
+                            "cannot convert {} array into {}",
                             self.data_type(),
                             stringify!($arrow_type)
                         )


### PR DESCRIPTION
This can help debug incorrect data types.