### PR TITLE
Add support for decoding StringArray in LargeUtf8 schema

### DIFF
--- a/serde_arrow/src/test_end_to_end/mod.rs
+++ b/serde_arrow/src/test_end_to_end/mod.rs
@@ -4,3 +4,4 @@ mod issue_137_schema_like_from_arrow_schema;
 mod issue_90;
 mod test_docs_examples;
 mod test_items;
+mod test_strings;

--- a/serde_arrow/src/test_end_to_end/test_strings.rs
+++ b/serde_arrow/src/test_end_to_end/test_strings.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::{
+    self as serde_arrow,
+    _impl::arrow::_raw::{
+        array::{LargeStringArray, RecordBatch, StringArray},
+        schema::{DataType, Field, Schema},
+    },
+    internal::error::PanicOnError,
+    schema::{SchemaLike, TracingOptions},
+};
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+struct Record {
+    id: String,
+}
+
+#[test]
+fn test_short_strings() -> PanicOnError<()> {
+    let column: StringArray = vec!["foo", "bar"].into();
+
+    let fields = vec![Field::new("id", DataType::Utf8, false)];
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(fields.clone())),
+        vec![Arc::new(column.clone())],
+    )?;
+
+    let records: Vec<Record> = serde_arrow::from_arrow(&fields, batch.columns())?;
+
+    assert_eq!(
+        records,
+        vec![
+            Record {
+                id: "foo".to_string()
+            },
+            Record {
+                id: "bar".to_string()
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_large_strings_into_short_strings() -> PanicOnError<()> {
+    let column: LargeStringArray = vec!["foo", "bar"].into();
+
+    let deser_fields = vec![Field::new("id", DataType::Utf8, false)];
+    let batch_fields = vec![Field::new("id", DataType::LargeUtf8, false)];
+
+    assert_eq!(
+        Vec::<Field>::from_type::<Record>(TracingOptions::default())?,
+        batch_fields
+    );
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(batch_fields.clone())),
+        vec![Arc::new(column.clone())],
+    )?;
+
+    let result: Result<Vec<Record>, _> = serde_arrow::from_arrow(&deser_fields, batch.columns());
+
+    assert!(
+        result.is_err(),
+        "Reading large strings into a short strings array did not error"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_large_strings() -> PanicOnError<()> {
+    let column: LargeStringArray = vec!["foo", "bar"].into();
+
+    let fields = vec![Field::new("id", DataType::LargeUtf8, false)];
+    assert_eq!(
+        Vec::<Field>::from_type::<Record>(TracingOptions::default())?,
+        fields
+    );
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(fields.clone())),
+        vec![Arc::new(column.clone())],
+    )?;
+
+    let records: Vec<Record> = serde_arrow::from_arrow(&fields, batch.columns())?;
+
+    assert_eq!(
+        records,
+        vec![
+            Record {
+                id: "foo".to_string()
+            },
+            Record {
+                id: "bar".to_string()
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_short_strings_into_large_strings() -> PanicOnError<()> {
+    let column: StringArray = vec!["foo", "bar"].into();
+
+    let deser_fields = Vec::<_>::from_type::<Record>(TracingOptions::default())?;
+    let batch_fields = vec![Field::new("id", DataType::Utf8, false)];
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(batch_fields.clone())),
+        vec![Arc::new(column.clone())],
+    )?;
+
+    let records: Vec<Record> = serde_arrow::from_arrow(&deser_fields, batch.columns())?;
+
+    assert_eq!(
+        records,
+        vec![
+            Record {
+                id: "foo".to_string()
+            },
+            Record {
+                id: "bar".to_string()
+            },
+        ]
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
`Vec::<_>::from_type::<Record>(TracingOptions::default())?` is very
convenient, but it always returns a `LargeUtf8` type for String fields
in `Record`, which prevents using it before decoding from a
`RecordBatch` which may contain a `StringArray` (instead of the expected
`LargeStringArray`).

This change adds a fallback on error when decoding what we expect to be
a `LargeUtf8`, to try decoding it as a `Utf8` as a last resort.

(this PR contains the commit from #142 to avoid a merge conflict)