### PR TITLE
Add support for borrowed strings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 ## 0.11.0
 
 `0.11.0` does contain any anticipated breaking changes. However it's a major
-refactoring and may change some untested behavior.
+refactoring and may change untested behavior.
 
 - Remove the bytecode deserializer and use the serde API directly
   - Easier to understand and extend
@@ -13,6 +13,7 @@ refactoring and may change some untested behavior.
 - Add `Date32` and `Time64` support
 - Allow to use `arrow` schemas in `SchemaLike::from_value()`, e.g., `let fields
   = Vec::<Field>::from_value(&batch.schema())`.
+- Allow to perform zero-copy deserialization from arrow arrays
 - Fix bug in `SchemaLike::from_type()` for nested unions
 
 ### Thanks
@@ -23,6 +24,8 @@ The following people contributed to this release:
   ([PR](https://github.com/chmp/serde_arrow/pull/147))
 - [@progval](https://github.com/progval) added additional error messages
   ([PR](https://github.com/chmp/serde_arrow/pull/142))
+- [@](https://github.com/gstvg) contributed zero-copy deserialization
+  ([PR](https://github.com/chmp/serde_arrow/pull/151))
 
 ## 0.10.0
 

--- a/serde_arrow/src/arrow2_impl/api.rs
+++ b/serde_arrow/src/arrow2_impl/api.rs
@@ -173,7 +173,7 @@ where
 /// # }
 /// ```
 ///
-pub fn from_arrow2<'de, T, A>(fields: &'de [Field], arrays: &'de [A]) -> Result<T>
+pub fn from_arrow2<'de, T, A>(fields: &[Field], arrays: &'de [A]) -> Result<T>
 where
     T: Deserialize<'de>,
     A: AsRef<dyn Array>,

--- a/serde_arrow/src/arrow_impl/api.rs
+++ b/serde_arrow/src/arrow_impl/api.rs
@@ -200,7 +200,7 @@ pub fn to_arrow<T: Serialize + ?Sized>(fields: &[Field], items: &T) -> Result<Ve
 /// # }
 /// ```
 ///
-pub fn from_arrow<'de, T, A>(fields: &'de [Field], arrays: &'de [A]) -> Result<T>
+pub fn from_arrow<'de, T, A>(fields: &[Field], arrays: &'de [A]) -> Result<T>
 where
     T: Deserialize<'de>,
     A: AsRef<dyn Array>,

--- a/serde_arrow/src/internal/deserialization/string_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/string_deserializer.rs
@@ -22,7 +22,7 @@ impl<'a, O: IntoUsize> StringDeserializer<'a, O> {
         }
     }
 
-    pub fn next(&mut self) -> Result<Option<&str>> {
+    pub fn next(&mut self) -> Result<Option<&'a str>> {
         if self.next + 1 > self.offsets.len() {
             fail!("Tried to deserialize a value from an exhausted StringDeserializer");
         }
@@ -42,7 +42,7 @@ impl<'a, O: IntoUsize> StringDeserializer<'a, O> {
         Ok(Some(s))
     }
 
-    pub fn next_required(&mut self) -> Result<&str> {
+    pub fn next_required(&mut self) -> Result<&'a str> {
         self.next()?.ok_or_else(|| {
             error!("Tried to deserialize a value from StringDeserializer, but value is missing")
         })
@@ -90,7 +90,7 @@ impl<'a, O: IntoUsize> SimpleDeserializer<'a> for StringDeserializer<'a, O> {
     }
 
     fn deserialize_str<V: serde::de::Visitor<'a>>(&mut self, visitor: V) -> Result<V::Value> {
-        visitor.visit_str(self.next_required()?)
+        visitor.visit_borrowed_str(self.next_required()?)
     }
 
     fn deserialize_string<V: serde::de::Visitor<'a>>(&mut self, visitor: V) -> Result<V::Value> {

--- a/serde_arrow/src/internal/tracing/from_type.rs
+++ b/serde_arrow/src/internal/tracing/from_type.rs
@@ -112,7 +112,7 @@ impl<'de, 'a> serde::de::Deserializer<'de> for TraceAny<'a> {
 
     fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         self.0.ensure_utf8()?;
-        visitor.visit_str("")
+        visitor.visit_borrowed_str("")
     }
 
     fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {

--- a/serde_arrow/src/test_impls/primitives.rs
+++ b/serde_arrow/src/test_impls/primitives.rs
@@ -412,6 +412,62 @@ fn nullable_str_u32() {
 }
 
 #[test]
+fn borrowed_str() {
+    let field = GenericField::new("item", GenericDataType::LargeUtf8, false);
+
+    type Ty<'a> = &'a str;
+
+    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn nullabe_borrowed_str() {
+    let field = GenericField::new("item", GenericDataType::LargeUtf8, true);
+
+    type Ty<'a> = Option<&'a str>;
+
+    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn borrowed_str_u32() {
+    let field = GenericField::new("item", GenericDataType::Utf8, false);
+
+    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn nullabe_borrowed_str_u32() {
+    let field = GenericField::new("item", GenericDataType::Utf8, true);
+
+    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
 fn newtype_i64() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct I64(i64);

--- a/serde_arrow/src/test_impls/primitives.rs
+++ b/serde_arrow/src/test_impls/primitives.rs
@@ -424,7 +424,7 @@ fn borrowed_str() {
         .trace_schema_from_samples(&values, TracingOptions::default())
         .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
         .serialize(&values)
-        .deserialize(&values);
+        .deserialize_borrowed(&values);
 }
 
 #[test]
@@ -440,7 +440,7 @@ fn nullabe_borrowed_str() {
         .trace_schema_from_samples(&values, TracingOptions::default())
         .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
         .serialize(&values)
-        .deserialize(&values);
+        .deserialize_borrowed(&values);
 }
 
 #[test]
@@ -452,7 +452,7 @@ fn borrowed_str_u32() {
     Test::new()
         .with_schema(vec![field])
         .serialize(&values)
-        .deserialize(&values);
+        .deserialize_borrowed(&values);
 }
 
 #[test]
@@ -464,7 +464,7 @@ fn nullabe_borrowed_str_u32() {
     Test::new()
         .with_schema(vec![field])
         .serialize(&values)
-        .deserialize(&values);
+        .deserialize_borrowed(&values);
 }
 
 #[test]

--- a/serde_arrow/src/test_impls/utils.rs
+++ b/serde_arrow/src/test_impls/utils.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, env, sync::Arc};
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     _impl::{arrow, arrow2},
@@ -66,6 +66,7 @@ impl Test {
     pub fn with_schema<T: Serialize>(mut self, schema: T) -> Self {
         self.schema =
             Some(SerdeArrowSchema::from_value(&schema).expect("Failed conversion of schema"));
+
         self
     }
 
@@ -204,10 +205,10 @@ impl Test {
         self
     }
 
-    pub fn deserialize<T: DeserializeOwned + std::fmt::Debug + PartialEq>(
-        self,
+    pub fn deserialize<'a, T: Deserialize<'a> + std::fmt::Debug + PartialEq>(
+        &'a self,
         items: &[T],
-    ) -> Self {
+    ) -> &Self {
         if self.impls.arrow {
             let fields = self.get_arrow_fields();
             let roundtripped: Vec<T> = crate::from_arrow(
@@ -237,7 +238,7 @@ impl Test {
         self
     }
 
-    pub fn check_nulls(self, nulls: &[&[bool]]) -> Self {
+    pub fn check_nulls(&self, nulls: &[&[bool]]) -> &Self {
         if self.impls.arrow {
             let Some(arrow_arrays) = self.arrays.arrow.as_ref() else {
                 panic!("cannot check_nulls without arrays");

--- a/serde_arrow/src/test_impls/utils.rs
+++ b/serde_arrow/src/test_impls/utils.rs
@@ -205,10 +205,20 @@ impl Test {
         self
     }
 
-    pub fn deserialize<'a, T: Deserialize<'a> + std::fmt::Debug + PartialEq>(
-        &'a self,
-        items: &[T],
-    ) -> &Self {
+    /// Test deserializing into an owned type
+    pub fn deserialize<T>(self, items: &[T]) -> Self
+    where
+        T: for<'a> Deserialize<'a> + std::fmt::Debug + PartialEq,
+    {
+        self.deserialize_borrowed(items);
+        self
+    }
+
+    /// Test deserializing by borrowing from the previously serialized arrays
+    pub fn deserialize_borrowed<'a, T>(&'a self, items: &[T])
+    where
+        T: Deserialize<'a> + std::fmt::Debug + PartialEq,
+    {
         if self.impls.arrow {
             let fields = self.get_arrow_fields();
             let roundtripped: Vec<T> = crate::from_arrow(
@@ -234,11 +244,9 @@ impl Test {
             .expect("Failed arrow2 deserialization");
             assert_eq!(roundtripped, items);
         }
-
-        self
     }
 
-    pub fn check_nulls(&self, nulls: &[&[bool]]) -> &Self {
+    pub fn check_nulls(self, nulls: &[&[bool]]) -> Self {
         if self.impls.arrow {
             let Some(arrow_arrays) = self.arrays.arrow.as_ref() else {
                 panic!("cannot check_nulls without arrays");

--- a/x.py
+++ b/x.py
@@ -203,7 +203,7 @@ def example():
     help="If given, skip arrow2 implementations in tests",
 )
 @arg("test_name", nargs="?", help="Filter of test names")
-def test(test_name, backtrace=False, full=False, skip_arrow2=False):
+def test(test_name=None, backtrace=False, full=False, skip_arrow2=False):
     import os
 
     if not full:


### PR DESCRIPTION
This allows deserializing into strings borrowed from the original arrow arrays
