### PR TITLE
Add support to serialize enums as type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,16 +69,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
-name = "array-init-cursor"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "arrow"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+dependencies = [
+ "arrow-arith",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data 51.0.0",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema 51.0.0",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "half 2.2.1",
+ "num",
+]
 
 [[package]]
 name = "arrow-array"
@@ -498,6 +528,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core",
+ "regex",
+]
+
+[[package]]
 name = "arrow-data"
 version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,13 +727,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-format"
-version = "0.8.1"
+name = "arrow-ipc"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07884ea216994cdc32a2d5f8274a8bee979cfe90274b83f86f440866ee3132c7"
+checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
 dependencies = [
- "planus",
- "serde",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-cast",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -705,6 +758,36 @@ dependencies = [
  "num",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select",
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-row"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "half 2.2.1",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -857,6 +940,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-string"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+dependencies = [
+ "arrow-array 51.0.0",
+ "arrow-buffer 51.0.0",
+ "arrow-data 51.0.0",
+ "arrow-schema 51.0.0",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "arrow2"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,7 +983,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c63cf31f1416ed2fab8f91e8488e10129f47bd89c553ec354a06751d5697f3"
 dependencies = [
  "ahash 0.8.3",
- "arrow-format",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -955,6 +1054,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -1243,6 +1348,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,10 +1454,20 @@ checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 name = "example"
 version = "0.1.0"
 dependencies = [
- "arrow2 0.17.0",
+ "arrow",
  "chrono",
  "serde",
  "serde_arrow",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "23.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+dependencies = [
+ "bitflags",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1499,6 +1635,12 @@ checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
@@ -1688,15 +1830,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "planus"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
-dependencies = [
- "array-init-cursor",
-]
 
 [[package]]
 name = "plotters"

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 0.11.6
+
+- Add support to serialize enums without data (e.g., `enum E { A, B, C}`) as
+  strings by setting the corresponding field to a string value (`Utf`,
+  `LargeUtf`, `Dictionary(_, Utf8)`, `Dictionary(_, LargeUtf8`)
+- Allow to trace enums without data as dictionary encoded strings by setting
+  `enums_without_data_as_strings` to `true` in `TracingOptions`
+
 ## 0.11.5
 
 - Add `serde_arrow::Serializer`

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow2 = {version = "0.17", features = ["io_ipc"] }
+arrow = {version = "51.0", features = ["ipc"] }
 
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 
-serde_arrow = { path = "../serde_arrow", features = ["arrow2-0-17"] }
+serde_arrow = { path = "../serde_arrow", features = ["arrow-51"] }

--- a/serde_arrow/src/internal/deserialization/dictionary_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/dictionary_deserializer.rs
@@ -6,6 +6,7 @@ use crate::internal::{
 };
 
 use super::{
+    enums_as_string_impl::EnumAccess,
     integer_deserializer::Integer, list_deserializer::IntoUsize,
     simple_deserializer::SimpleDeserializer, utils::ArrayBufferIterator,
 };
@@ -76,5 +77,16 @@ impl<'de, K: Integer, V: IntoUsize> SimpleDeserializer<'de> for DictionaryDeseri
 
     fn deserialize_string<VV: Visitor<'de>>(&mut self, visitor: VV) -> Result<VV::Value> {
         visitor.visit_string(self.next_str()?.to_owned())
+    }
+
+    fn deserialize_enum<VV: Visitor<'de>>(
+        &mut self,
+        _: &'static str,
+        _: &'static [&'static str],
+        visitor: VV,
+    ) -> Result<VV::Value> {
+        let variant = self.next_str()?;
+        visitor.visit_enum(EnumAccess(variant))
+
     }
 }

--- a/serde_arrow/src/internal/deserialization/dictionary_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/dictionary_deserializer.rs
@@ -6,8 +6,7 @@ use crate::internal::{
 };
 
 use super::{
-    enums_as_string_impl::EnumAccess,
-    integer_deserializer::Integer, list_deserializer::IntoUsize,
+    enums_as_string_impl::EnumAccess, integer_deserializer::Integer, list_deserializer::IntoUsize,
     simple_deserializer::SimpleDeserializer, utils::ArrayBufferIterator,
 };
 
@@ -87,6 +86,5 @@ impl<'de, K: Integer, V: IntoUsize> SimpleDeserializer<'de> for DictionaryDeseri
     ) -> Result<VV::Value> {
         let variant = self.next_str()?;
         visitor.visit_enum(EnumAccess(variant))
-
     }
 }

--- a/serde_arrow/src/internal/deserialization/enums_as_string_impl.rs
+++ b/serde_arrow/src/internal/deserialization/enums_as_string_impl.rs
@@ -1,0 +1,96 @@
+use serde::de::Visitor;
+
+use crate::internal::error::{fail, Error,Result};
+
+pub struct EnumAccess<'de>(pub &'de str);
+
+impl<'a, 'de> serde::de::EnumAccess<'de> for EnumAccess<'a> {
+    type Error = Error;
+    type Variant = UnitVariant;
+
+    fn variant_seed<V: serde::de::DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error> {
+        struct SeedDeserializer<'a>(&'a str);
+
+        macro_rules! unimplemented {
+            ($lifetime:lifetime, $name:ident $($tt:tt)*) => {
+                fn $name<V: Visitor<$lifetime>>(self $($tt)*, _: V) -> Result<V::Value> {
+                    fail!("{} is not implemented", stringify!($name))
+                }
+            };
+        }
+
+        impl<'de, 'a> serde::de::Deserializer<'de> for SeedDeserializer<'a> {
+            type Error = Error;
+
+            fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+                self.deserialize_str(visitor)
+            }
+
+            fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+                self.deserialize_str(visitor)
+            }
+
+            fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+                visitor.visit_str(self.0)
+            }
+
+            fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+                visitor.visit_string(self.0.to_owned())
+            }
+
+            unimplemented!('de, deserialize_u64);
+            unimplemented!('de, deserialize_bool);
+            unimplemented!('de, deserialize_i8);
+            unimplemented!('de, deserialize_i16);
+            unimplemented!('de, deserialize_i32);
+            unimplemented!('de, deserialize_i64);
+            unimplemented!('de, deserialize_u8);
+            unimplemented!('de, deserialize_u16);
+            unimplemented!('de, deserialize_u32);
+            unimplemented!('de, deserialize_f32);
+            unimplemented!('de, deserialize_f64);
+            unimplemented!('de, deserialize_char);
+            unimplemented!('de, deserialize_bytes);
+            unimplemented!('de, deserialize_byte_buf);
+            unimplemented!('de, deserialize_option);
+            unimplemented!('de, deserialize_unit);
+            unimplemented!('de, deserialize_unit_struct, _: &'static str);
+            unimplemented!('de, deserialize_newtype_struct, _: &'static str);
+            unimplemented!('de, deserialize_seq);
+            unimplemented!('de, deserialize_tuple, _: usize);
+            unimplemented!('de, deserialize_tuple_struct, _: &'static str, _: usize);
+            unimplemented!('de, deserialize_map);
+            unimplemented!('de, deserialize_struct, _: &'static str, _: &'static [&'static str]);
+            unimplemented!('de, deserialize_enum, _: &'static str, _: &'static [&'static str]);
+            unimplemented!('de, deserialize_ignored_any);
+        }
+
+        Ok((seed.deserialize(SeedDeserializer(self.0))?, UnitVariant))
+    }
+}
+
+pub struct UnitVariant;
+
+impl<'de> serde::de::VariantAccess<'de> for UnitVariant {
+    type Error = Error;
+
+    fn newtype_variant_seed<T: serde::de::DeserializeSeed<'de>>(self, _: T) -> Result<T::Value> {
+        fail!("cannot deserialize enums with data from strings")
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _: &'static [&'static str],
+        _: V,
+    ) -> Result<V::Value> {
+        fail!("cannot deserialize enums with data from strings")
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(self, _: usize, _: V) -> Result<V::Value> {
+        fail!("cannot deserialize enums with data from strings")
+    }
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/serde_arrow/src/internal/deserialization/enums_as_string_impl.rs
+++ b/serde_arrow/src/internal/deserialization/enums_as_string_impl.rs
@@ -1,6 +1,6 @@
 use serde::de::Visitor;
 
-use crate::internal::error::{fail, Error,Result};
+use crate::internal::error::{fail, Error, Result};
 
 pub struct EnumAccess<'de>(pub &'de str);
 
@@ -8,7 +8,10 @@ impl<'a, 'de> serde::de::EnumAccess<'de> for EnumAccess<'a> {
     type Error = Error;
     type Variant = UnitVariant;
 
-    fn variant_seed<V: serde::de::DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error> {
+    fn variant_seed<V: serde::de::DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error> {
         struct SeedDeserializer<'a>(&'a str);
 
         macro_rules! unimplemented {
@@ -78,11 +81,7 @@ impl<'de> serde::de::VariantAccess<'de> for UnitVariant {
         fail!("cannot deserialize enums with data from strings")
     }
 
-    fn struct_variant<V: Visitor<'de>>(
-        self,
-        _: &'static [&'static str],
-        _: V,
-    ) -> Result<V::Value> {
+    fn struct_variant<V: Visitor<'de>>(self, _: &'static [&'static str], _: V) -> Result<V::Value> {
         fail!("cannot deserialize enums with data from strings")
     }
 

--- a/serde_arrow/src/internal/deserialization/mod.rs
+++ b/serde_arrow/src/internal/deserialization/mod.rs
@@ -6,6 +6,7 @@ pub mod date64_deserializer;
 pub mod decimal_deserializer;
 pub mod dictionary_deserializer;
 pub mod enum_deserializer;
+pub mod enums_as_string_impl;
 pub mod float_deserializer;
 pub mod float_impls;
 pub mod integer_deserializer;

--- a/serde_arrow/src/internal/deserialization/string_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/string_deserializer.rs
@@ -3,7 +3,7 @@ use crate::internal::{
     error::{error, fail, Result},
 };
 
-use super::{list_deserializer::IntoUsize, simple_deserializer::SimpleDeserializer};
+use super::{enums_as_string_impl::EnumAccess, list_deserializer::IntoUsize, simple_deserializer::SimpleDeserializer};
 
 pub struct StringDeserializer<'a, O: IntoUsize> {
     pub data: &'a [u8],
@@ -95,5 +95,15 @@ impl<'a, O: IntoUsize> SimpleDeserializer<'a> for StringDeserializer<'a, O> {
 
     fn deserialize_string<V: serde::de::Visitor<'a>>(&mut self, visitor: V) -> Result<V::Value> {
         visitor.visit_string(self.next_required()?.to_owned())
+    }
+
+    fn deserialize_enum<V: serde::de::Visitor<'a>>(
+        &mut self,
+        _: &'static str,
+        _: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        let variant = self.next_required()?;
+        visitor.visit_enum(EnumAccess(variant))
     }
 }

--- a/serde_arrow/src/internal/deserialization/string_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/string_deserializer.rs
@@ -3,7 +3,10 @@ use crate::internal::{
     error::{error, fail, Result},
 };
 
-use super::{enums_as_string_impl::EnumAccess, list_deserializer::IntoUsize, simple_deserializer::SimpleDeserializer};
+use super::{
+    enums_as_string_impl::EnumAccess, list_deserializer::IntoUsize,
+    simple_deserializer::SimpleDeserializer,
+};
 
 pub struct StringDeserializer<'a, O: IntoUsize> {
     pub data: &'a [u8],

--- a/serde_arrow/src/internal/schema/from_samples/mod.rs
+++ b/serde_arrow/src/internal/schema/from_samples/mod.rs
@@ -342,7 +342,6 @@ impl EventSink for StructTracer {
 
                     // field was missing in previous samples
                     if self.seen_samples != 0 {
-                        println!("{key}");
                         field.tracer.mark_nullable();
                     }
 

--- a/serde_arrow/src/internal/schema/tracing_options.rs
+++ b/serde_arrow/src/internal/schema/tracing_options.rs
@@ -83,6 +83,12 @@ pub struct TracingOptions {
     /// enums with many variants.
     pub from_type_budget: usize,
 
+    /// Whether to encode enums without data as strings
+    ///
+    /// If `false` enums without data are encoded as Union arrays with Null
+    /// fields. If `true` enums without data are encoded as dictionaries.
+    pub enums_without_data_as_strings: bool,
+
     /// Internal field to improve error messages for the different tracing
     /// functions
     pub(crate) tracing_mode: TracingMode,
@@ -98,6 +104,7 @@ impl Default for TracingOptions {
             guess_dates: false,
             from_type_budget: 100,
             tracing_mode: TracingMode::Unknown,
+            enums_without_data_as_strings: false,
         }
     }
 }
@@ -140,6 +147,12 @@ impl TracingOptions {
     /// Set [`from_type_budget`](#structfield.from_type_budget)
     pub fn from_type_budget(mut self, value: usize) -> Self {
         self.from_type_budget = value;
+        self
+    }
+
+    /// Set [`enums_without_data_as_strings`](#structfield.enums_without_data_as_strings)
+    pub fn enums_without_data_as_strings(mut self, value: bool) -> Self {
+        self.enums_without_data_as_strings = value;
         self
     }
 

--- a/serde_arrow/src/internal/schema/tracing_options.rs
+++ b/serde_arrow/src/internal/schema/tracing_options.rs
@@ -87,6 +87,35 @@ pub struct TracingOptions {
     ///
     /// If `false` enums without data are encoded as Union arrays with Null
     /// fields. If `true` enums without data are encoded as dictionaries.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[cfg(has_arrow)]
+    /// # fn main() -> serde_arrow::Result<()> {
+    /// # use serde_arrow::_impl::arrow;
+    /// # use arrow::datatypes::FieldRef;
+    /// # use serde_arrow::{schema::{SchemaLike, TracingOptions}, utils::Item};
+    /// #
+    /// ##[derive(Serialize, Deserialize)]
+    /// enum U {
+    ///     A,
+    ///     B,
+    ///     C,
+    /// }
+    ///
+    /// let items = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
+    ///
+    /// let tracing_options = TracingOptions::default().enums_without_data_as_strings(true);
+    /// let fields = Vec::<FieldRef>::from_type::<Item<U>>(tracing_options)?;
+    /// let batch = serde_arrow::to_record_batch(&fields, &items)?;
+    /// #
+    /// # Ok(())
+    /// # }
+    /// # #[cfg(not(has_arrow))]
+    /// # fn main() { }
+    /// ```
     pub enums_without_data_as_strings: bool,
 
     /// Internal field to improve error messages for the different tracing

--- a/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
@@ -2,7 +2,11 @@ use std::collections::HashMap;
 
 use serde::Serialize;
 
-use crate::internal::{common::Mut, error::Result, schema::GenericField};
+use crate::internal::{
+    common::Mut,
+    error::{fail, Result},
+    schema::GenericField,
+};
 
 use super::{array_builder::ArrayBuilder, utils::SimpleSerializer};
 
@@ -71,5 +75,35 @@ impl SimpleSerializer for DictionaryUtf8Builder {
         variant: &'static str,
     ) -> Result<()> {
         self.serialize_str(variant)
+    }
+
+    fn serialize_tuple_variant_start<'this>(
+        &'this mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<&'this mut super::ArrayBuilder> {
+        fail!("Cannot serialize enum with data as string");
+    }
+
+    fn serialize_struct_variant_start<'this>(
+        &'this mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<&'this mut super::ArrayBuilder> {
+        fail!("Cannot serialize enum with data as string");
+    }
+
+    fn serialize_newtype_variant<V: serde::Serialize + ?Sized>(
+        &mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &V,
+    ) -> Result<()> {
+        fail!("Cannot serialize enum with data as string");
     }
 }

--- a/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
@@ -63,4 +63,13 @@ impl SimpleSerializer for DictionaryUtf8Builder {
         };
         idx.serialize(Mut(self.indices.as_mut()))
     }
+
+    fn serialize_unit_variant(
+        &mut self,
+        _: &'static str,
+        _: u32,
+        variant: &'static str,
+    ) -> Result<()> {
+        self.serialize_str(variant)
+    }
 }

--- a/serde_arrow/src/internal/serialization/utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/utf8_builder.rs
@@ -1,6 +1,6 @@
-use crate::{
-    internal::common::{MutableBitBuffer, MutableOffsetBuffer, Offset},
-    Result,
+use crate::internal::{
+    common::{MutableBitBuffer, MutableOffsetBuffer, Offset},
+    error::{fail, Result},
 };
 
 use super::utils::{push_validity, push_validity_default, SimpleSerializer};
@@ -66,5 +66,35 @@ impl<O: Offset> SimpleSerializer for Utf8Builder<O> {
         variant: &'static str,
     ) -> Result<()> {
         self.serialize_str(variant)
+    }
+
+    fn serialize_tuple_variant_start<'this>(
+        &'this mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<&'this mut super::ArrayBuilder> {
+        fail!("Cannot serialize enum with data as string");
+    }
+
+    fn serialize_struct_variant_start<'this>(
+        &'this mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<&'this mut super::ArrayBuilder> {
+        fail!("Cannot serialize enum with data as string");
+    }
+
+    fn serialize_newtype_variant<V: serde::Serialize + ?Sized>(
+        &mut self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &V,
+    ) -> Result<()> {
+        fail!("Cannot serialize enum with data as string");
     }
 }

--- a/serde_arrow/src/internal/serialization/utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/utf8_builder.rs
@@ -58,4 +58,13 @@ impl<O: Offset> SimpleSerializer for Utf8Builder<O> {
 
         Ok(())
     }
+
+    fn serialize_unit_variant(
+        &mut self,
+        _: &'static str,
+        _: u32,
+        variant: &'static str,
+    ) -> Result<()> {
+        self.serialize_str(variant)
+    }
 }

--- a/serde_arrow/src/test_with_arrow/impls/union.rs
+++ b/serde_arrow/src/test_with_arrow/impls/union.rs
@@ -394,3 +394,49 @@ fn fieldless_unions_as_dictionary() {
         .serialize(&values)
         .deserialize(&values);
 }
+
+#[test]
+fn fieldless_unions_as_utf8() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum U {
+        A,
+        B,
+        C,
+    }
+
+    // type Ty = U;
+
+    // let tracing_options = TracingOptions::default().allow_null_fields(true);
+
+    let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
+
+    Test::new()
+        .with_schema(json!([{"name": "item", "data_type": "Utf8"}]))
+        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
+        // .trace_schema_from_samples(&values, tracing_options.clone())
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn fieldless_unions_as_large_utf8() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum U {
+        A,
+        B,
+        C,
+    }
+
+    // type Ty = U;
+
+    // let tracing_options = TracingOptions::default().allow_null_fields(true);
+
+    let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
+
+    Test::new()
+        .with_schema(json!([{"name": "item", "data_type": "LargeUtf8"}]))
+        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
+        // .trace_schema_from_samples(&values, tracing_options.clone())
+        .serialize(&values)
+        .deserialize(&values);
+}

--- a/serde_arrow/src/test_with_arrow/impls/union.rs
+++ b/serde_arrow/src/test_with_arrow/impls/union.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::{
     internal::schema::{GenericDataType, GenericField},
@@ -363,3 +364,33 @@ test_generic!(
         assert_error(&res, "Serialization failed: an unknown variant");
     }
 );
+
+#[test]
+fn fieldless_unions_as_dictionary() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum U {
+        A,
+        B,
+        C,
+    }
+
+    // type Ty = U;
+
+    // let tracing_options = TracingOptions::default().allow_null_fields(true);
+
+    let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
+
+    Test::new()
+        .with_schema(json!([{
+            "name": "item",
+            "data_type": "Dictionary",
+            "children": [
+                {"name": "key", "data_type": "U32"},
+                {"name": "value", "data_type": "LargeUtf8"},
+            ]
+        }]))
+        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
+        // .trace_schema_from_samples(&values, tracing_options.clone())
+        .serialize(&values)
+        .deserialize(&values);
+}

--- a/serde_arrow/src/test_with_arrow/impls/union.rs
+++ b/serde_arrow/src/test_with_arrow/impls/union.rs
@@ -374,10 +374,7 @@ fn fieldless_unions_as_dictionary() {
         C,
     }
 
-    // type Ty = U;
-
-    // let tracing_options = TracingOptions::default().allow_null_fields(true);
-
+    let tracing_options = TracingOptions::default().enums_without_data_as_strings(true);
     let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
 
     Test::new()
@@ -389,8 +386,8 @@ fn fieldless_unions_as_dictionary() {
                 {"name": "value", "data_type": "LargeUtf8"},
             ]
         }]))
-        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
-        // .trace_schema_from_samples(&values, tracing_options.clone())
+        .trace_schema_from_type::<Item<U>>(tracing_options.clone())
+        .trace_schema_from_samples(&values, tracing_options.clone())
         .serialize(&values)
         .deserialize(&values);
 }
@@ -404,16 +401,10 @@ fn fieldless_unions_as_utf8() {
         C,
     }
 
-    // type Ty = U;
-
-    // let tracing_options = TracingOptions::default().allow_null_fields(true);
-
     let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
 
     Test::new()
         .with_schema(json!([{"name": "item", "data_type": "Utf8"}]))
-        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
-        // .trace_schema_from_samples(&values, tracing_options.clone())
         .serialize(&values)
         .deserialize(&values);
 }
@@ -427,16 +418,10 @@ fn fieldless_unions_as_large_utf8() {
         C,
     }
 
-    // type Ty = U;
-
-    // let tracing_options = TracingOptions::default().allow_null_fields(true);
-
     let values = [Item(U::A), Item(U::B), Item(U::C), Item(U::A)];
 
     Test::new()
         .with_schema(json!([{"name": "item", "data_type": "LargeUtf8"}]))
-        // .trace_schema_from_type::<Item<Ty>>(tracing_options.clone())
-        // .trace_schema_from_samples(&values, tracing_options.clone())
         .serialize(&values)
         .deserialize(&values);
 }


### PR DESCRIPTION
- [x] Update Changelog
- [x] Decide whether to warn for fieldless enums serialized as unions without explicit overwrite
- [x] Add docs on enum encodings (e.g., in the quickstart)
- [x] ~~Add support to serialize the variant as an integer~~ *A*: discriminant is not related to the set discriminant