### PR TITLE
Add tracing option for reading strings as (Large)Utf8

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,9 +12,12 @@ New features
   `jiff::Timestamp`, `jiff::Span`, `jiff::SignedDuration`)
 - Add support for tracing lists as `List` instead of `LargeList` by setting
   `sequence_as_large_list` to `false` in `TracingOptions`
+- Add support for tracing strings and strings in dictionaries as `Utf8` instead of
+  `LargeUtf8` by setting `strings_as_large_utf8` to `false` in `TracingOptions`
 
 ### Thanks
 - [@jkylling](https://github.com/jkylling) added support for tracing lists as `List`
+  and strings as `Utf8` 
 
 ## 0.12.0
 

--- a/serde_arrow/src/internal/schema/from_samples/mod.rs
+++ b/serde_arrow/src/internal/schema/from_samples/mod.rs
@@ -337,7 +337,7 @@ impl<'a> serde::ser::Serializer for TracerSerializer<'a> {
         try_(|| {
             #[allow(clippy::collapsible_else_if)]
             let (ty, st) = if !self.0.get_options().guess_dates {
-                (DataType::LargeUtf8, None)
+                (self.0.get_options().string_type(), None)
             } else {
                 if chrono::matches_naive_datetime(s) {
                     (DataType::Date64, Some(Strategy::NaiveStrAsDate64))
@@ -348,7 +348,7 @@ impl<'a> serde::ser::Serializer for TracerSerializer<'a> {
                 } else if chrono::matches_naive_date(s) {
                     (DataType::Date32, None)
                 } else {
-                    (DataType::LargeUtf8, None)
+                    (self.0.get_options().string_type(), None)
                 }
             };
             self.0.ensure_primitive_with_strategy(ty, st)

--- a/serde_arrow/src/internal/schema/from_type/mod.rs
+++ b/serde_arrow/src/internal/schema/from_type/mod.rs
@@ -197,7 +197,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for TraceAny<'a> {
 
     fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         try_(|| {
-            self.0.ensure_utf8(DataType::LargeUtf8, None)?;
+            self.0
+                .ensure_utf8(self.0.get_options().string_type(), None)?;
             visitor.visit_borrowed_str("")
         })
         .ctx(&self)
@@ -205,7 +206,8 @@ impl<'de, 'a> serde::de::Deserializer<'de> for TraceAny<'a> {
 
     fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         try_(|| {
-            self.0.ensure_utf8(DataType::LargeUtf8, None)?;
+            self.0
+                .ensure_utf8(self.0.get_options().string_type(), None)?;
             visitor.visit_string(Default::default())
         })
         .ctx(&self)

--- a/serde_arrow/src/internal/schema/tracer.rs
+++ b/serde_arrow/src/internal/schema/tracer.rs
@@ -525,7 +525,7 @@ fn coerce_primitive_type(
 ) -> Result<(DataType, bool, Option<Strategy>)> {
     use DataType::{
         Date64, Float32, Float64, Int16, Int32, Int64, Int8, LargeUtf8, Null, UInt16, UInt32,
-        UInt64, UInt8,
+        UInt64, UInt8, Utf8,
     };
 
     let res = match (prev, curr) {
@@ -576,8 +576,10 @@ fn coerce_primitive_type(
         // incompatible formats, coerce to string
         ((Date64, nullable, _), (LargeUtf8, _)) => (LargeUtf8, nullable, None),
         ((LargeUtf8, nullable, _), (Date64, _)) => (LargeUtf8, nullable, None),
+        ((Date64, nullable, _), (Utf8, _)) => (Utf8, nullable, None),
+        ((Utf8, nullable, _), (Date64, _)) => (Utf8, nullable, None),
         ((Date64, nullable, prev_st), (Date64, curr_st)) if prev_st != curr_st.as_ref() => {
-            (LargeUtf8, nullable, None)
+            (options.string_type(), nullable, None)
         }
         ((prev_ty, _, prev_st), (curr_ty, curr_st)) => {
             let extra = if is_numeric(prev_ty) && is_numeric(&curr_ty) {

--- a/serde_arrow/src/test/schema_tracing.rs
+++ b/serde_arrow/src/test/schema_tracing.rs
@@ -230,24 +230,41 @@ mod json_date64_utc_null {
 
 /// Mixing different date formats or dates and non-dates, results in Strings
 mod json_date64_to_string_coercions {
-    use super::*;
-
     macro_rules! test {
         ($name:ident, $($data:tt)*) => {
-            #[test]
-            fn $name() -> PanicOnError<()> {
-                let expected = SerdeArrowSchema::from_value(&json!([
-                    {
-                        "name": "date",
-                        "data_type": "LargeUtf8",
-                        "nullable": true,
-                    },
-                ]))?;
+            mod $name {
+                use super::super::*;
 
-                let data = json!($($data)*);
-                let actual = SerdeArrowSchema::from_samples(&data, TracingOptions::default().guess_dates(true))?;
-                assert_eq!(actual, expected);
-                Ok(())
+                #[test]
+                fn large_utf8() -> PanicOnError<()> {
+                    let expected = SerdeArrowSchema::from_value(&json!([
+                       {
+                          "name": "date",
+                          "data_type": "LargeUtf8",
+                          "nullable": true,
+                      },
+                  ]))?;
+
+                  let data = json!($($data)*);
+                  let actual = SerdeArrowSchema::from_samples(&data, TracingOptions::default().guess_dates(true))?;
+                  assert_eq!(actual, expected);
+                  Ok(())
+              }
+              #[test]
+                fn utf8() -> PanicOnError<()> {
+                    let expected = SerdeArrowSchema::from_value(&json!([
+                       {
+                          "name": "date",
+                          "data_type": "Utf8",
+                          "nullable": true,
+                      },
+                  ]))?;
+
+                  let data = json!($($data)*);
+                  let actual = SerdeArrowSchema::from_samples(&data, TracingOptions::default().guess_dates(true).strings_as_large_utf8(false))?;
+                  assert_eq!(actual, expected);
+                  Ok(())
+              }
             }
         };
     }

--- a/serde_arrow/src/test_with_arrow/impls/primitives.rs
+++ b/serde_arrow/src/test_with_arrow/impls/primitives.rs
@@ -370,6 +370,28 @@ fn str() {
 }
 
 #[test]
+fn str_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    type Ty = String;
+    let values = [
+        Item(String::from("a")),
+        Item(String::from("b")),
+        Item(String::from("c")),
+        Item(String::from("d")),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(
+            &values,
+            TracingOptions::default().strings_as_large_utf8(false),
+        )
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default().strings_as_large_utf8(false))
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
 fn nullable_str() {
     let field = new_field("item", DataType::LargeUtf8, true);
     type Ty = Option<String>;


### PR DESCRIPTION
Should be on top of https://github.com/chmp/serde_arrow/pull/245

Is there something missing in `coerce_primitive_type`? There seems to be an asymmetry between Utf8 and LargeUtf8 there.

Could some instructions on how to run tests be added to the README. To run the full test suite the appropriate `--features` and `--cfg` flags must be set, and I was a bit confused about which flags to set to make the tests run.