### PR TITLE
Incorrect deserialization from sliced arrays

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Bug fixes:
 
 - Fixed deserialization from sliced arrays ([#248](https://github.com/chmp/serde_arrow/issues/248)).
   Note that the current solution requires up front work when constructing the array deserializers,
-  as described in the issue. The removal of the performance penality is tracked in
+  as described in the issue. The removal of the performance penalty is tracked in
   ([#250](https://github.com/chmp/serde_arrow/issues/250))
 
 ### Thanks

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,19 @@
 # Change log
 
+## 0.12.2
+
+Bug fixes:
+
+- Fixed deserialization from sliced arrays ([#248](https://github.com/chmp/serde_arrow/issues/248)).
+  Note that the current solution requires up front work when constructing the array deserializers,
+  as described in the issue. The removal of the performance penality is tracked in
+  ([#250](https://github.com/chmp/serde_arrow/issues/250))
+
+### Thanks
+
+- [@jkylling](https://github.com/jkylling) for reporting
+  ([#248](https://github.com/chmp/serde_arrow/issues/248)) and for discussing potential solutions
+
 ## 0.12.1
 
 New features

--- a/serde_arrow/src/internal/deserialization/array_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/array_deserializer.rs
@@ -296,7 +296,12 @@ impl<'a> ArrayDeserializer<'a> {
                     fields.push((field_meta.name, field_deserializer))
                 }
 
-                Ok(Self::Enum(EnumDeserializer::new(path, view.types, fields)))
+                Ok(Self::Enum(EnumDeserializer::new(
+                    path,
+                    view.types,
+                    view.offsets,
+                    fields,
+                )?))
             }
         }
     }

--- a/serde_arrow/src/internal/deserialization/enum_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/enum_deserializer.rs
@@ -57,6 +57,18 @@ fn verify_offsets(type_ids: &[i8], offsets: &[i32]) -> Result<()> {
             }
             last_offsets.insert(type_id, offset);
         } else {
+            if offset != 0 {
+                fail!(
+                    concat!(
+                        "Invalid offsets in enum array for item {idx}:",
+                        "serde_arrow only supports initial zero offsets.",
+                        "Current offset for type {type_id}: {offset}",
+                    ),
+                    idx = idx,
+                    type_id = type_id,
+                    offset = offset,
+                );
+            }
             last_offsets.insert(type_id, offset);
         }
     }

--- a/serde_arrow/src/internal/deserialization/list_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/list_deserializer.rs
@@ -23,11 +23,16 @@ pub struct ListDeserializer<'a, O: Offset> {
 impl<'a, O: Offset> ListDeserializer<'a, O> {
     pub fn new(
         path: String,
-        item: ArrayDeserializer<'a>,
+        mut item: ArrayDeserializer<'a>,
         offsets: &'a [O],
         validity: Option<BitsWithOffset<'a>>,
     ) -> Result<Self> {
         check_supported_list_layout(validity, offsets)?;
+
+        // skip any unused values up front
+        for _ in 0..offsets[0].try_into_usize()? {
+            item.deserialize_ignored_any(serde::de::IgnoredAny)?;
+        }
 
         Ok(Self {
             path,

--- a/serde_arrow/src/internal/deserialization/list_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/list_deserializer.rs
@@ -28,11 +28,7 @@ impl<'a, O: Offset> ListDeserializer<'a, O> {
         validity: Option<BitsWithOffset<'a>>,
     ) -> Result<Self> {
         check_supported_list_layout(validity, offsets)?;
-
-        // skip any unused values up front
-        for _ in 0..offsets[0].try_into_usize()? {
-            item.deserialize_ignored_any(serde::de::IgnoredAny)?;
-        }
+        item.skip(offsets[0].try_into_usize()?)?;
 
         Ok(Self {
             path,

--- a/serde_arrow/src/internal/deserialization/map_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/map_deserializer.rs
@@ -31,11 +31,9 @@ impl<'a> MapDeserializer<'a> {
     ) -> Result<Self> {
         check_supported_list_layout(validity, offsets)?;
 
-        // skip any unused values up front
-        for _ in 0..usize::try_from(offsets[0])? {
-            key.deserialize_ignored_any(serde::de::IgnoredAny)?;
-            value.deserialize_ignored_any(serde::de::IgnoredAny)?;
-        }
+        let initial_offset = usize::try_from(offsets[0])?;
+        key.skip(initial_offset)?;
+        value.skip(initial_offset)?;
 
         Ok(Self {
             path,

--- a/serde_arrow/src/internal/deserialization/map_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/map_deserializer.rs
@@ -24,12 +24,18 @@ pub struct MapDeserializer<'a> {
 impl<'a> MapDeserializer<'a> {
     pub fn new(
         path: String,
-        key: ArrayDeserializer<'a>,
-        value: ArrayDeserializer<'a>,
+        mut key: ArrayDeserializer<'a>,
+        mut value: ArrayDeserializer<'a>,
         offsets: &'a [i32],
         validity: Option<BitsWithOffset<'a>>,
     ) -> Result<Self> {
         check_supported_list_layout(validity, offsets)?;
+
+        // skip any unused values up front
+        for _ in 0..usize::try_from(offsets[0])? {
+            key.deserialize_ignored_any(serde::de::IgnoredAny)?;
+            value.deserialize_ignored_any(serde::de::IgnoredAny)?;
+        }
 
         Ok(Self {
             path,

--- a/serde_arrow/src/internal/deserialization/simple_deserializer.rs
+++ b/serde_arrow/src/internal/deserialization/simple_deserializer.rs
@@ -1,4 +1,7 @@
-use serde::{de::Visitor, Deserializer};
+use serde::{
+    de::{IgnoredAny, Visitor},
+    Deserializer,
+};
 
 use crate::internal::{
     error::{fail, Context, Error, Result},
@@ -7,6 +10,13 @@ use crate::internal::{
 
 #[allow(unused)]
 pub trait SimpleDeserializer<'de>: Context + Sized {
+    fn skip(&mut self, n: usize) -> Result<()> {
+        for _ in 0..n {
+            self.deserialize_any(IgnoredAny)?;
+        }
+        Ok(())
+    }
+
     fn deserialize_any<V: Visitor<'de>>(&mut self, visitor: V) -> Result<V::Value> {
         fail!(in self, "Deserializer does not implement deserialize_any");
     }

--- a/serde_arrow/src/test/deserialization/list.rs
+++ b/serde_arrow/src/test/deserialization/list.rs
@@ -1,0 +1,40 @@
+use crate::internal::{
+    arrow::{ArrayView, FieldMeta, ListArrayView, PrimitiveArrayView},
+    deserialization::array_deserializer::ArrayDeserializer,
+    testing::assert_error_contains,
+};
+
+#[test]
+fn invalid_offsets() {
+    let reference = ListArrayView {
+        validity: None,
+        offsets: &[],
+        meta: FieldMeta {
+            name: String::from("element"),
+            nullable: false,
+            metadata: Default::default(),
+        },
+        element: Box::new(ArrayView::Int32(PrimitiveArrayView {
+            validity: None,
+            values: &[0, 1, 2, 3, 4, 5],
+        })),
+    };
+
+    let view = ArrayView::List(ListArrayView {
+        offsets: &[],
+        ..reference.clone()
+    });
+    assert_error_contains(
+        &ArrayDeserializer::new(String::from("foo"), None, view),
+        "non empty",
+    );
+
+    let view = ArrayView::List(ListArrayView {
+        offsets: &[0, 5, 2],
+        ..reference.clone()
+    });
+    assert_error_contains(
+        &ArrayDeserializer::new(String::from("foo"), None, view),
+        "monotonically increasing",
+    );
+}

--- a/serde_arrow/src/test/deserialization/mod.rs
+++ b/serde_arrow/src/test/deserialization/mod.rs
@@ -1,0 +1,2 @@
+mod list;
+mod r#union;

--- a/serde_arrow/src/test/deserialization/union.rs
+++ b/serde_arrow/src/test/deserialization/union.rs
@@ -33,17 +33,6 @@ fn non_consecutive_offsets() {
         ),
     ];
 
-    // second type does not start at 0
-    let view = ArrayView::DenseUnion(DenseUnionArrayView {
-        types: &[0, 0, 1],
-        offsets: &[0, 1, 2],
-        fields: fields.clone(),
-    });
-    assert_error_contains(
-        &ArrayDeserializer::new(String::from("foo"), None, view),
-        "initial zero offsets",
-    );
-
     // first type has an unused element
     let view = ArrayView::DenseUnion(DenseUnionArrayView {
         types: &[0, 0, 1],

--- a/serde_arrow/src/test/deserialization/union.rs
+++ b/serde_arrow/src/test/deserialization/union.rs
@@ -1,0 +1,68 @@
+use crate::internal::{
+    arrow::{ArrayView, DenseUnionArrayView, FieldMeta, PrimitiveArrayView},
+    deserialization::array_deserializer::ArrayDeserializer,
+    testing::assert_error_contains,
+};
+
+#[test]
+fn non_consecutive_offsets() {
+    let fields = vec![
+        (
+            0,
+            ArrayView::Int32(PrimitiveArrayView {
+                validity: None,
+                values: &[1, 2, 3, 4, 5, 6],
+            }),
+            FieldMeta {
+                name: String::from("foo"),
+                nullable: false,
+                metadata: Default::default(),
+            },
+        ),
+        (
+            1,
+            ArrayView::Int32(PrimitiveArrayView {
+                validity: None,
+                values: &[1, 2, 3, 4, 5, 6],
+            }),
+            FieldMeta {
+                name: String::from("foo"),
+                nullable: false,
+                metadata: Default::default(),
+            },
+        ),
+    ];
+
+    // second type does not start at 0
+    let view = ArrayView::DenseUnion(DenseUnionArrayView {
+        types: &[0, 0, 1],
+        offsets: &[0, 1, 2],
+        fields: fields.clone(),
+    });
+    assert_error_contains(
+        &ArrayDeserializer::new(String::from("foo"), None, view),
+        "initial zero offsets",
+    );
+
+    // first type has an unused element
+    let view = ArrayView::DenseUnion(DenseUnionArrayView {
+        types: &[0, 0, 1],
+        offsets: &[0, 2, 0],
+        fields: fields.clone(),
+    });
+    assert_error_contains(
+        &ArrayDeserializer::new(String::from("foo"), None, view),
+        "consecutive offsets",
+    );
+
+    // first type has an unused element
+    let view = ArrayView::DenseUnion(DenseUnionArrayView {
+        types: &[0, 0, 0],
+        offsets: &[0, 1, 4],
+        fields: fields.clone(),
+    });
+    assert_error_contains(
+        &ArrayDeserializer::new(String::from("foo"), None, view),
+        "consecutive offsets",
+    );
+}

--- a/serde_arrow/src/test/mod.rs
+++ b/serde_arrow/src/test/mod.rs
@@ -1,4 +1,5 @@
 mod api_chrono;
+mod deserialization;
 mod error_messages;
 mod jiff;
 mod schema_like;

--- a/serde_arrow/src/test_with_arrow/issue_248_sliced_lists.rs
+++ b/serde_arrow/src/test_with_arrow/issue_248_sliced_lists.rs
@@ -1,0 +1,43 @@
+use crate::_impl::arrow::datatypes::FieldRef;
+use crate::{
+    self as serde_arrow,
+    schema::{SchemaLike, TracingOptions},
+};
+
+#[test]
+fn strings() {
+    #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+    struct Struct {
+        string: String,
+    }
+    let data = (1..=10)
+        .map(|x| Struct {
+            string: x.to_string(),
+        })
+        .collect::<Vec<_>>();
+    let fields = Vec::<FieldRef>::from_type::<Struct>(TracingOptions::default()).unwrap();
+    let batch = serde_arrow::to_record_batch(&fields, &data).unwrap();
+    let batch = batch.slice(5, 5);
+
+    let actual: Vec<Struct> = serde_arrow::from_record_batch(&batch).unwrap();
+    assert_eq!(data[5..10], actual);
+}
+
+#[test]
+fn vec_of_strings() {
+    #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+    struct Struct {
+        string: Vec<String>,
+    }
+    let data = (1..=10)
+        .map(|x| Struct {
+            string: vec![x.to_string()],
+        })
+        .collect::<Vec<_>>();
+    let fields = Vec::<FieldRef>::from_type::<Struct>(TracingOptions::default()).unwrap();
+    let batch = serde_arrow::to_record_batch(&fields, &data).unwrap();
+    let batch = batch.slice(5, 5);
+
+    let actual: Vec<Struct> = serde_arrow::from_record_batch(&batch).unwrap();
+    assert_eq!(data[5..10], actual);
+}

--- a/serde_arrow/src/test_with_arrow/issue_248_sliced_lists.rs
+++ b/serde_arrow/src/test_with_arrow/issue_248_sliced_lists.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use crate::_impl::arrow::datatypes::FieldRef;
+use crate::internal::testing::hash_map;
 use crate::{
     self as serde_arrow,
     schema::{SchemaLike, TracingOptions},
@@ -35,6 +38,27 @@ fn vec_of_strings() {
         })
         .collect::<Vec<_>>();
     let fields = Vec::<FieldRef>::from_type::<Struct>(TracingOptions::default()).unwrap();
+    let batch = serde_arrow::to_record_batch(&fields, &data).unwrap();
+    let batch = batch.slice(5, 5);
+
+    let actual: Vec<Struct> = serde_arrow::from_record_batch(&batch).unwrap();
+    assert_eq!(data[5..10], actual);
+}
+
+#[test]
+fn map_of_strings() {
+    #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+    struct Struct {
+        string: HashMap<String, String>,
+    }
+    let data = (1..=10)
+        .map(|x| Struct {
+            string: hash_map!(x.to_string() => x.to_string()),
+        })
+        .collect::<Vec<_>>();
+    let fields =
+        Vec::<FieldRef>::from_type::<Struct>(TracingOptions::default().map_as_struct(false))
+            .unwrap();
     let batch = serde_arrow::to_record_batch(&fields, &data).unwrap();
     let batch = batch.slice(5, 5);
 

--- a/serde_arrow/src/test_with_arrow/issue_248_slices_deserialization.rs
+++ b/serde_arrow/src/test_with_arrow/issue_248_slices_deserialization.rs
@@ -100,11 +100,38 @@ fn enums() {
         Str(String),
     }
 
+    // Note: this works, as the initial offset for the remaining variants is 0
     let data = vec![
         Item(Value::I64(0)),
         Item(Value::I64(1)),
         Item(Value::I32(2)),
         Item(Value::Str(String::from("3"))),
+    ];
+    let fields = Vec::<FieldRef>::from_type::<Item<Value>>(TracingOptions::default()).unwrap();
+
+    let batch = serde_arrow::to_record_batch(&fields, &data).unwrap();
+    let batch = batch.slice(2, 2);
+
+    let actual: Vec<Item<Value>> = serde_arrow::from_record_batch(&batch).unwrap();
+    assert_eq!(data[2..4], actual);
+}
+
+#[test]
+fn enums_2() {
+    #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+    enum Value {
+        I64(i64),
+        I32(i32),
+        Str(String),
+    }
+
+    // note use always the same variant to force the sliced offsets to result in non-zero initial
+    // offset for type 0
+    let data = vec![
+        Item(Value::I64(0)),
+        Item(Value::I64(1)),
+        Item(Value::I64(2)),
+        Item(Value::I64(3)),
     ];
     let fields = Vec::<FieldRef>::from_type::<Item<Value>>(TracingOptions::default()).unwrap();
 

--- a/serde_arrow/src/test_with_arrow/mod.rs
+++ b/serde_arrow/src/test_with_arrow/mod.rs
@@ -2,6 +2,7 @@
 //!
 mod impls;
 mod issue_137_schema_like_from_arrow_schema;
+mod issue_248_sliced_lists;
 mod issue_35_preserve_metadata;
 mod issue_90_top_level_nulls_in_structs;
 mod items_wrapper;

--- a/serde_arrow/src/test_with_arrow/mod.rs
+++ b/serde_arrow/src/test_with_arrow/mod.rs
@@ -2,7 +2,7 @@
 //!
 mod impls;
 mod issue_137_schema_like_from_arrow_schema;
-mod issue_248_sliced_lists;
+mod issue_248_slices_deserialization;
 mod issue_35_preserve_metadata;
 mod issue_90_top_level_nulls_in_structs;
 mod items_wrapper;


### PR DESCRIPTION
See #248 

- [x] Map 
  - fixed
  - add test for non-supported list layouts (see below)
- [x] List 
   - fixed
  - add test for unsupported list layouts (non-increasing offsets, with data for null values)
- [x] Binary - no changes required
- [x] Utf8 - no changes required
- [x] Dictionary
- [x] Union 
  - no changes required for slicing
  - but the impl assumes no skipped values in the underlying arrays and should verify this
  - alternative design: track for each child array the current position and skip as necessary
  - Test with "malicious" examples e.g., build union array with skipped values, non-consecutive offsets, ...
- [x] Update changelog
