### PR TITLE
Fix incorrect nullability in build_builder.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,14 @@
 - Allow to treat deserializers as sequence of deserializers by iterating over them or accessing
   individual items
 
+### Thanks
+
+The following people contributed to this release:
+
+- [@ryzhyk](https://github.com/ryzhyk) discovered and fixed a bug introduced during refactoring
+  ([#261](https://github.com/chmp/serde_arrow/pull/261))
+
+
 ## 0.12.3
 
 - Add `arrow=54` support

--- a/serde_arrow/src/internal/serialization/outer_sequence_builder.rs
+++ b/serde_arrow/src/internal/serialization/outer_sequence_builder.rs
@@ -208,9 +208,12 @@ fn build_builder(path: String, field: &Field) -> Result<ArrayBuilder> {
             let n = usize::try_from(*n).ctx(&ctx)?;
             A::FixedSizeBinary(FixedSizeBinaryBuilder::new(path, n, field.nullable))
         }
-        T::Map(field, sorted) => {
-            let DataType::Struct(entries_field) = &field.data_type else {
-                fail!("unexpected data type for map array: {:?}", field.data_type);
+        T::Map(entry_field, sorted) => {
+            let DataType::Struct(entries_field) = &entry_field.data_type else {
+                fail!(
+                    "unexpected data type for map array: {:?}",
+                    entry_field.data_type
+                );
             };
             let Some(keys_field) = entries_field.first() else {
                 fail!("Missing keys field for map");
@@ -220,18 +223,18 @@ fn build_builder(path: String, field: &Field) -> Result<ArrayBuilder> {
             };
             let keys_path = format!(
                 "{path}.{entries_name}.{keys__name}",
-                entries_name = ChildName(&field.name),
+                entries_name = ChildName(&entry_field.name),
                 keys__name = ChildName(&keys_field.name),
             );
             let values_path = format!(
                 "{path}.{entries_name}.{values_name}",
-                entries_name = ChildName(&field.name),
+                entries_name = ChildName(&entry_field.name),
                 values_name = ChildName(&values_field.name),
             );
 
             let meta = MapMeta {
                 sorted: *sorted,
-                entries_name: field.name.clone(),
+                entries_name: entry_field.name.clone(),
                 keys: meta_from_field(keys_field.clone()),
                 values: meta_from_field(values_field.clone()),
             };

--- a/serde_arrow/src/test_with_arrow/impls/arrow_map.rs
+++ b/serde_arrow/src/test_with_arrow/impls/arrow_map.rs
@@ -334,6 +334,7 @@ fn hash_maps_nullable() {
     let values: &[Item<Ty>] = &[
         Item(Some(hash_map! {0 => true, 1 => false, 2 => true})),
         Item(Some(hash_map! {3 => false, 4 => true})),
+        Item(None),
         Item(Some(hash_map! {})),
     ];
 


### PR DESCRIPTION
The `Map(field)` pattern shadowed the `field` variable and ended up incorrectly using the `nullability` flag from the inner rather than the outer type.  This caused errors like:

```
Cannot push null for non-nullable array (data_type: "Map(..)", field: "$.c2")
```

although the map type was in fact nullable.

Here is a test that used to fail (I was not sure how to best incorporate it in the code base):

```rust
#[test]
fn nullable_map() {
    let schema = Schema::new(vec![
        arrow::datatypes::Field::new("id", DataType::Int64, false),
        arrow::datatypes::Field::new_map(
            "m",
            "entries",
            arrow::datatypes::Field::new("key", DataType::Utf8, false),
            arrow::datatypes::Field::new("value", DataType::Int64, false),
            false,
            true,
        ),
    ]);

    #[derive(serde::Serialize)]
    struct Struct {
        id: i64,
        m: Option<std::collections::HashMap<String, i64>>,
    }

    let data = [Struct { id: 1, m: None }];

    to_record_batch(&schema.fields().as_ref(), &data).unwrap();
}
```