### PR TITLE
Fix #264

### DIFF
--- a/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/dictionary_utf8_builder.rs
@@ -41,7 +41,10 @@ impl DictionaryUtf8Builder {
         self.indices.is_nullable()
     }
 
-    pub fn into_array(self) -> Result<Array> {
+    pub fn into_array(mut self) -> Result<Array> {
+        if self.index.is_empty() {
+            self.values.serialize_str("")?;
+        }
         Ok(Array::Dictionary(DictionaryArray {
             keys: Box::new((*self.indices).into_array()?),
             values: Box::new((*self.values).into_array()?),
@@ -58,7 +61,7 @@ impl Context for DictionaryUtf8Builder {
 
 impl SimpleSerializer for DictionaryUtf8Builder {
     fn serialize_default(&mut self) -> Result<()> {
-        try_(|| self.indices.serialize_none()).ctx(self)
+        try_(|| self.indices.serialize_default()).ctx(self)
     }
 
     fn serialize_none(&mut self) -> Result<()> {

--- a/serde_arrow/src/internal/serialization/union_builder.rs
+++ b/serde_arrow/src/internal/serialization/union_builder.rs
@@ -87,6 +87,13 @@ impl Context for UnionBuilder {
 }
 
 impl SimpleSerializer for UnionBuilder {
+    fn serialize_default(&mut self) -> Result<()> {
+        let mut ctx = BTreeMap::new();
+        self.annotate(&mut ctx);
+
+        try_(|| self.serialize_variant(0)?.serialize_unit()).ctx(&ctx)
+    }
+
     fn serialize_unit_variant(
         &mut self,
         _: &'static str,

--- a/serde_arrow/src/test_with_arrow/impls/issue_264_nested_nullable.rs
+++ b/serde_arrow/src/test_with_arrow/impls/issue_264_nested_nullable.rs
@@ -1,0 +1,48 @@
+use super::utils::Test;
+
+use serde::Serialize;
+use serde_json::json;
+
+#[test]
+fn nested_nullable() {
+    #[derive(Serialize)]
+    struct S {
+        a: Option<T>,
+    }
+
+    #[derive(Serialize)]
+    struct T {
+        a: U,
+    }
+
+    #[derive(Serialize)]
+    enum U {
+        #[allow(unused)]
+        A,
+    }
+
+    Test::new()
+        .with_schema(
+            &json!([{"name": "a", "data_type": "Struct", "nullable": true, "children": [
+                {"name": "a", "data_type": "Struct", "children": [
+                    {"name": "a", "data_type": "Dictionary", "children": [
+                        {"name": "key", "data_type": "U32"},
+                        {"name": "value", "data_type": "LargeUtf8"},
+                    ]}
+                ]}
+            ]}]),
+        )
+        .serialize(&[S { a: None }]);
+
+    Test::new()
+        .with_schema(
+            &json!([{"name": "a", "data_type": "Struct", "nullable": true, "children": [
+                {"name": "a", "data_type": "Struct", "children": [
+                    {"name": "a", "data_type": "Union", "children": [
+                        {"name": "A", "data_type": "Null", "nullable": true},
+                    ]}
+                ]}
+            ]}]),
+        )
+        .serialize(&[S { a: None }]);
+}

--- a/serde_arrow/src/test_with_arrow/impls/mod.rs
+++ b/serde_arrow/src/test_with_arrow/impls/mod.rs
@@ -42,3 +42,5 @@ mod wrappers;
 mod issue_74_unknown_fields;
 mod issue_79_declared_but_missing_fields;
 mod issue_90_type_tracing;
+
+mod issue_264_nested_nullable;


### PR DESCRIPTION
This is the proposal to fix serialisation of union and dictionary arrays when they are called from `serialize_default':
- serialize an empty string into `DictionaryUtf8Builder' if no values are present
- call `serialize_default` from its `serialise_default` instead of `serialize_none` (this one can be also made so that `serialise_none` is called if the array is nullable)
- `UnionBuilder` now serializes its first variant inside of `serialize_default`

Fixes #264 