### PR TITLE
Allow conversion to strings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 0.13.2
+
+- Allow primitive to string conversion ([#272](https://github.com/chmp/serde_arrow/pull/272))
+  - Adds the option `allow_to_string` to `TracerOptions` to allow numbers, booleans and chars
+    to coerce to strings (`false` by default)
+  - Allows for numbers, booleans and chars to be serialized to strings
+
 ## 0.13.1
 
 - Allow to use enums / unions in nullable structs. The arrow format requires that each child field

--- a/serde_arrow/src/internal/schema/tracing_options.rs
+++ b/serde_arrow/src/internal/schema/tracing_options.rs
@@ -85,6 +85,14 @@ pub struct TracingOptions {
     /// - signed  + float -> f64
     pub coerce_numbers: bool,
 
+    /// If `true`, allow any ToString type to coerce into a Utf8. The default is `false`.
+    ///
+    /// This option may be helpful when dealing with data formats which have no distinction
+    /// of types like CSV and may parse a value from a string
+    ///
+    /// This will allow conversion of any numeric, char or boolean value
+    pub allow_to_string: bool,
+
     /// If `true`, try to auto detect datetimes in string columns. The default is `false`.
     ///
     /// Currently the naive datetime (`YYYY-MM-DDThh:mm:ss`) and UTC datetimes
@@ -228,6 +236,7 @@ impl Default for TracingOptions {
             map_as_struct: true,
             string_dictionary_encoding: false,
             coerce_numbers: false,
+            allow_to_string: false,
             guess_dates: false,
             from_type_budget: 100,
             enums_without_data_as_strings: false,
@@ -277,6 +286,12 @@ impl TracingOptions {
     /// Set [`coerce_numbers`](#structfield.coerce_numbers)
     pub fn coerce_numbers(mut self, value: bool) -> Self {
         self.coerce_numbers = value;
+        self
+    }
+
+    /// Set [`allow_to_string`](#structfield.allow_to_string)
+    pub fn allow_to_string(mut self, value: bool) -> Self {
+        self.allow_to_string = value;
         self
     }
 

--- a/serde_arrow/src/internal/serialization/utf8_builder.rs
+++ b/serde_arrow/src/internal/serialization/utf8_builder.rs
@@ -89,6 +89,54 @@ impl<A: Utf8BuilderArray> SimpleSerializer for Utf8Builder<A> {
         try_(|| self.array.push_scalar_value(v.as_bytes())).ctx(self)
     }
 
+    fn serialize_i8(&mut self, v: i8) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_i16(&mut self, v: i16) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_i32(&mut self, v: i32) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_i64(&mut self, v: i64) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_u8(&mut self, v: u8) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_u16(&mut self, v: u16) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_u32(&mut self, v: u32) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_u64(&mut self, v: u64) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_f32(&mut self, v: f32) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_f64(&mut self, v: f64) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_char(&mut self, v: char) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
+    fn serialize_bool(&mut self, v: bool) -> Result<()> {
+        try_(|| self.array.push_scalar_value(v.to_string().as_bytes())).ctx(self)
+    }
+
     fn serialize_unit_variant(
         &mut self,
         _: &'static str,

--- a/serde_arrow/src/test_with_arrow/impls/arrow_utf8.rs
+++ b/serde_arrow/src/test_with_arrow/impls/arrow_utf8.rs
@@ -1,0 +1,296 @@
+use marrow::datatypes::DataType;
+
+use crate::internal::{schema::TracingOptions, utils::Item};
+
+use super::utils::{new_field, Test};
+
+#[test]
+fn str() {
+    let field = new_field("item", DataType::LargeUtf8, false);
+    type Ty = String;
+    let values = [
+        Item(String::from("a")),
+        Item(String::from("b")),
+        Item(String::from("c")),
+        Item(String::from("d")),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn str_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    type Ty = String;
+    let values = [
+        Item(String::from("a")),
+        Item(String::from("b")),
+        Item(String::from("c")),
+        Item(String::from("d")),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(
+            &values,
+            TracingOptions::default().strings_as_large_utf8(false),
+        )
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default().strings_as_large_utf8(false))
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn nullable_str() {
+    let field = new_field("item", DataType::LargeUtf8, true);
+    type Ty = Option<String>;
+    let values = [
+        Item(Some(String::from("a"))),
+        Item(None),
+        Item(None),
+        Item(Some(String::from("d"))),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn str_u32() {
+    let field = new_field("item", DataType::Utf8, false);
+    let values = [
+        Item(String::from("a")),
+        Item(String::from("b")),
+        Item(String::from("c")),
+        Item(String::from("d")),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn nullable_str_u32() {
+    let field = new_field("item", DataType::Utf8, true);
+    let values = [
+        Item(Some(String::from("a"))),
+        Item(None),
+        Item(None),
+        Item(Some(String::from("d"))),
+    ];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize(&values);
+}
+
+#[test]
+fn borrowed_str() {
+    let field = new_field("item", DataType::LargeUtf8, false);
+
+    type Ty<'a> = &'a str;
+
+    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize_borrowed(&values);
+}
+
+#[test]
+fn nullabe_borrowed_str() {
+    let field = new_field("item", DataType::LargeUtf8, true);
+
+    type Ty<'a> = Option<&'a str>;
+
+    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
+
+    Test::new()
+        .with_schema(vec![field])
+        .trace_schema_from_samples(&values, TracingOptions::default())
+        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
+        .serialize(&values)
+        .deserialize_borrowed(&values);
+}
+
+#[test]
+fn borrowed_str_u32() {
+    let field = new_field("item", DataType::Utf8, false);
+
+    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize_borrowed(&values);
+}
+
+#[test]
+fn nullabe_borrowed_str_u32() {
+    let field = new_field("item", DataType::Utf8, true);
+
+    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&values)
+        .deserialize_borrowed(&values);
+}
+
+#[test]
+fn i8_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(-1i8), Item(0), Item(1), Item(10)];
+    let output = [Item("-1"), Item("0"), Item("1"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn i16_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(-1i16), Item(0), Item(1), Item(10)];
+    let output = [Item("-1"), Item("0"), Item("1"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+#[test]
+fn i32_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(-1i32), Item(0), Item(1), Item(10)];
+    let output = [Item("-1"), Item("0"), Item("1"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn i64_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(-1i64), Item(0), Item(1), Item(10)];
+    let output = [Item("-1"), Item("0"), Item("1"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn u8_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(0u8), Item(1), Item(2), Item(10)];
+    let output = [Item("0"), Item("1"), Item("2"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn u16_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(0u16), Item(1), Item(2), Item(10)];
+    let output = [Item("0"), Item("1"), Item("2"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn u32_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(0u32), Item(1), Item(2), Item(10)];
+    let output = [Item("0"), Item("1"), Item("2"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn u64_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(0u64), Item(1), Item(2), Item(10)];
+    let output = [Item("0"), Item("1"), Item("2"), Item("10")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn f32_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(1.0f32), Item(0.5), Item(-0.5), Item(10.5)];
+    let output = [Item("1"), Item("0.5"), Item("-0.5"), Item("10.5")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn f64_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(1.0f64), Item(0.5), Item(-0.5), Item(10.5)];
+    let output = [Item("1"), Item("0.5"), Item("-0.5"), Item("10.5")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn bool_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item(true), Item(false)];
+    let output = [Item("true"), Item("false")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}
+
+#[test]
+fn char_to_utf8() {
+    let field = new_field("item", DataType::Utf8, false);
+    let input = [Item('a'), Item('b'), Item('c')];
+    let output = [Item("a"), Item("b"), Item("c")];
+
+    Test::new()
+        .with_schema(vec![field])
+        .serialize(&input)
+        .deserialize_borrowed(&output);
+}

--- a/serde_arrow/src/test_with_arrow/impls/mod.rs
+++ b/serde_arrow/src/test_with_arrow/impls/mod.rs
@@ -17,6 +17,7 @@ mod arrow_struct;
 mod arrow_time;
 mod arrow_timestamp;
 mod arrow_union;
+mod arrow_utf8;
 #[cfg(has_arrow_bytes_view_support)]
 mod arrow_utf8_view;
 

--- a/serde_arrow/src/test_with_arrow/impls/primitives.rs
+++ b/serde_arrow/src/test_with_arrow/impls/primitives.rs
@@ -1,19 +1,10 @@
-use marrow::datatypes::{DataType, Field};
+use marrow::datatypes::DataType;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::internal::{schema::TracingOptions, utils::Item};
 
-use super::utils::Test;
-
-fn new_field(name: &str, data_type: DataType, nullable: bool) -> Field {
-    Field {
-        name: name.to_owned(),
-        data_type,
-        nullable,
-        metadata: Default::default(),
-    }
-}
+use super::utils::{new_field, Test};
 
 #[test]
 fn null() {
@@ -345,154 +336,6 @@ fn f16_from_f64() {
         .with_schema(vec![field])
         .serialize(&values)
         .deserialize(&values);
-}
-
-#[test]
-fn str() {
-    let field = new_field("item", DataType::LargeUtf8, false);
-    type Ty = String;
-    let values = [
-        Item(String::from("a")),
-        Item(String::from("b")),
-        Item(String::from("c")),
-        Item(String::from("d")),
-    ];
-
-    Test::new()
-        .with_schema(vec![field])
-        .trace_schema_from_samples(&values, TracingOptions::default())
-        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
-        .serialize(&values)
-        .deserialize(&values);
-}
-
-#[test]
-fn str_utf8() {
-    let field = new_field("item", DataType::Utf8, false);
-    type Ty = String;
-    let values = [
-        Item(String::from("a")),
-        Item(String::from("b")),
-        Item(String::from("c")),
-        Item(String::from("d")),
-    ];
-
-    Test::new()
-        .with_schema(vec![field])
-        .trace_schema_from_samples(
-            &values,
-            TracingOptions::default().strings_as_large_utf8(false),
-        )
-        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default().strings_as_large_utf8(false))
-        .serialize(&values)
-        .deserialize(&values);
-}
-
-#[test]
-fn nullable_str() {
-    let field = new_field("item", DataType::LargeUtf8, true);
-    type Ty = Option<String>;
-    let values = [
-        Item(Some(String::from("a"))),
-        Item(None),
-        Item(None),
-        Item(Some(String::from("d"))),
-    ];
-
-    Test::new()
-        .with_schema(vec![field])
-        .trace_schema_from_samples(&values, TracingOptions::default())
-        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
-        .serialize(&values)
-        .deserialize(&values);
-}
-
-#[test]
-fn str_u32() {
-    let field = new_field("item", DataType::Utf8, false);
-    let values = [
-        Item(String::from("a")),
-        Item(String::from("b")),
-        Item(String::from("c")),
-        Item(String::from("d")),
-    ];
-
-    Test::new()
-        .with_schema(vec![field])
-        .serialize(&values)
-        .deserialize(&values);
-}
-
-#[test]
-fn nullable_str_u32() {
-    let field = new_field("item", DataType::Utf8, true);
-    let values = [
-        Item(Some(String::from("a"))),
-        Item(None),
-        Item(None),
-        Item(Some(String::from("d"))),
-    ];
-
-    Test::new()
-        .with_schema(vec![field])
-        .serialize(&values)
-        .deserialize(&values);
-}
-
-#[test]
-fn borrowed_str() {
-    let field = new_field("item", DataType::LargeUtf8, false);
-
-    type Ty<'a> = &'a str;
-
-    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
-
-    Test::new()
-        .with_schema(vec![field])
-        .trace_schema_from_samples(&values, TracingOptions::default())
-        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
-        .serialize(&values)
-        .deserialize_borrowed(&values);
-}
-
-#[test]
-fn nullabe_borrowed_str() {
-    let field = new_field("item", DataType::LargeUtf8, true);
-
-    type Ty<'a> = Option<&'a str>;
-
-    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
-
-    Test::new()
-        .with_schema(vec![field])
-        .trace_schema_from_samples(&values, TracingOptions::default())
-        .trace_schema_from_type::<Item<Ty>>(TracingOptions::default())
-        .serialize(&values)
-        .deserialize_borrowed(&values);
-}
-
-#[test]
-fn borrowed_str_u32() {
-    let field = new_field("item", DataType::Utf8, false);
-
-    let values = [Item("a"), Item("b"), Item("c"), Item("d")];
-
-    Test::new()
-        .with_schema(vec![field])
-        .serialize(&values)
-        .deserialize_borrowed(&values);
-}
-
-#[test]
-fn nullabe_borrowed_str_u32() {
-    let field = new_field("item", DataType::Utf8, true);
-
-    let values = [Item(Some("a")), Item(None), Item(None), Item(Some("d"))];
-
-    Test::new()
-        .with_schema(vec![field])
-        .serialize(&values)
-        .deserialize_borrowed(&values);
 }
 
 #[test]

--- a/serde_arrow/src/test_with_arrow/impls/utils.rs
+++ b/serde_arrow/src/test_with_arrow/impls/utils.rs
@@ -1,3 +1,4 @@
+use marrow::datatypes::{DataType, Field};
 use std::{env, sync::Arc};
 
 use serde::{Deserialize, Serialize};
@@ -29,6 +30,15 @@ impl std::default::Default for Impls {
             arrow: !skip_arrow_tests,
             arrow2: !skip_arrow2_tests,
         }
+    }
+}
+
+pub fn new_field(name: &str, data_type: DataType, nullable: bool) -> Field {
+    Field {
+        name: name.to_owned(),
+        data_type,
+        nullable,
+        metadata: Default::default(),
     }
 }
 


### PR DESCRIPTION
I'm trying to create a tool to automatically convert files into parquet, but I'm running into issues with CSVs. Specifically the crate `csv` when doing `deserialize_any` will try to parse, if it can, strings into numeric values or booleans which causes errors here in the datatype conversion if a string just happens to be parseable into a number. So I've added this to allow number or boolean conversions to strings